### PR TITLE
Custom GHA Update

### DIFF
--- a/.github/workflows/new.yaml
+++ b/.github/workflows/new.yaml
@@ -16,12 +16,12 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Action Updater
-        uses: saadmk11/github-action-upgrade@skip-pr
+        uses: saadmk11/github-action-upgrade@v0.5.6
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
           commit_message: "Custom Commit Message"

--- a/.github/workflows/tmate.yml
+++ b/.github/workflows/tmate.yml
@@ -9,13 +9,13 @@ jobs:
     steps:
     - name: Public IP
       id: ip
-      uses: haythem/public-ip@v1
+      uses: haythem/public-ip@v1.2
 
     - name: Print Public IP
       run: |
         echo ${{ steps.ip.outputs.ipv4 }}
         echo ${{ steps.ip.outputs.ipv6 }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.5.0
     - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@v3.12


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[haythem/public-ip](https://github.com/haythem/public-ip)** published a new release [v1.2](https://github.com/haythem/public-ip/releases/tag/v1.2) on 2020-10-01T14:44:14Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v2.5.0](https://github.com/actions/checkout/releases/tag/v2.5.0) on 2022-10-13T15:51:55Z
* **[mxschmitt/action-tmate](https://github.com/mxschmitt/action-tmate)** published a new release [v3.12](https://github.com/mxschmitt/action-tmate/releases/tag/v3.12) on 2022-10-13T16:51:30Z
* **[saadmk11/github-action-upgrade](https://github.com/saadmk11/github-action-upgrade)** published a new release [v0.5.6](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.5.6) on 2021-04-10T18:11:33Z
